### PR TITLE
Fix SIGTERM return code

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func initSignals(s *Supervisor) {
 		sig := <-sigs
 		log.WithFields(log.Fields{"signal": sig}).Info("receive a signal to stop all process & exit")
 		s.procMgr.StopAllProcesses()
-		os.Exit(-1)
+		os.Exit(0)
 	}()
 
 }


### PR DESCRIPTION
Properly returns `0` instead of `-1` (`255`) on SIGTERM.

Already tested in the single container sidecar.