### PR TITLE
ENG-14392: Change initial log output to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,6 @@ func main() {
 	parser.Command.SubcommandsOptional = true
 	parser.CommandHandler = func(command flags.Commander, args []string) error {
 		if command == nil {
-			log.SetOutput(os.Stdout)
 			if options.Daemon {
 				logFile := getSupervisordLogFile(options.Configuration)
 				Daemonize(logFile, runServer)


### PR DESCRIPTION
Moves initial log lines like:
```
time="2024-09-11T20:03:26Z" level=info msg="load configuration from file" file=/etc/supervisor/supervisord.conf
time="2024-09-11T20:03:26Z" level=info msg="load configuration from file" file=/etc/supervisor/supervisord.prog.conf
```
to stderr. This is necessary because the log file has not been set at this point in the code (it comes from the config file).